### PR TITLE
Add 2Captcha support with external solver and env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ node hike_apply.js
 npm run test
 ```
 
+## 驗證碼設定
+
+預設為手動輸入驗證碼。如欲透過 2Captcha 自動解碼，可使用環境變數設定：
+
+```bash
+export CAPTCHA_MODE=2captcha
+export CAPTCHA_API_KEY=你的2Captcha_API_key
+node hike_apply.js
+```
+
+若未提供 `CAPTCHA_API_KEY` 或無法成功解析，程式會拋出錯誤。
+
 ## Excel 檔案格式
 
 Excel 檔案需包含以下工作表：
@@ -60,7 +72,7 @@ Excel 檔案需包含以下工作表：
 
 - 本工具僅供學習和展示用途
 - 請勿用於實際大量申請
-- 驗證碼需要手動輸入
+- 驗證碼預設需手動輸入，可透過 2Captcha 自動解碼
 - 建議在正式申請前先使用測試模式
 
 ## 授權

--- a/captcha_solver.js
+++ b/captcha_solver.js
@@ -1,0 +1,40 @@
+const fetch = global.fetch;
+
+async function solveWith2Captcha(base64Image, apiKey) {
+  if (!apiKey) {
+    throw new Error('2Captcha API key is missing');
+  }
+
+  const payload = new URLSearchParams({
+    key: apiKey,
+    method: 'base64',
+    body: base64Image,
+    json: '1'
+  });
+
+  const inRes = await fetch('https://2captcha.com/in.php', {
+    method: 'POST',
+    body: payload
+  });
+  const inJson = await inRes.json();
+  if (inJson.status !== 1) {
+    throw new Error(`2Captcha in.php error: ${inJson.request}`);
+  }
+  const requestId = inJson.request;
+
+  // Poll for result
+  for (let i = 0; i < 24; i++) {
+    await new Promise(r => setTimeout(r, 5000)); // wait 5s between requests
+    const res = await fetch(`https://2captcha.com/res.php?key=${apiKey}&action=get&id=${requestId}&json=1`);
+    const resJson = await res.json();
+    if (resJson.status === 1) {
+      return resJson.request;
+    }
+    if (resJson.request !== 'CAPCHA_NOT_READY') {
+      throw new Error(`2Captcha res.php error: ${resJson.request}`);
+    }
+  }
+  throw new Error('2Captcha timeout: captcha not solved in expected time');
+}
+
+module.exports = { solveWith2Captcha };

--- a/hike_apply.js
+++ b/hike_apply.js
@@ -13,10 +13,11 @@ const readline = require('readline');
 
 
 const { loadHikeExcelData, updateApplicationStatus } = require('./fill_apply_data');
-const { 
-  navigateToNextApplication, 
-  waitBetweenApplications 
+const {
+  navigateToNextApplication,
+  waitBetweenApplications
 } = require('./success_handler');
+const { solveWith2Captcha } = require('./captcha_solver');
 
 
 // ---------- Config ----------
@@ -24,7 +25,10 @@ const START_URL = 'https://hike.taiwan.gov.tw/apply_1.aspx?search=2';
 
 // Toggle when you add an external captcha service later:
 // { mode: 'manual' } or { mode: '2captcha', apiKey: 'XXXX' }
-const CAPTCHA_CONFIG = { mode: 'manual' };
+const CAPTCHA_CONFIG = {
+  mode: process.env.CAPTCHA_MODE || 'manual',
+  apiKey: process.env.CAPTCHA_API_KEY
+};
 
 // ---------- Utilities ----------
 function waitForAspNetIdle(page, timeoutMs = 15000) {
@@ -123,14 +127,19 @@ async function handleCaptcha(page, config = { mode: 'manual' }) {
   }
 
   if (config.mode === '2captcha') {
-    // Placeholder for future integration.
-    // 1) Grab the captcha image URL
+    const apiKey = config.apiKey || process.env.CAPTCHA_API_KEY;
+    if (!apiKey) {
+      throw new Error('2Captcha API key is required when using mode="2captcha"');
+    }
+
     const img = page.locator('#con_imgcode, img[alt*="驗證碼"], img[title*="驗證碼"]').first();
-    const src = await img.getAttribute('src');
-    // 2) Download the image (you may need cookies), send to 2Captcha, get solution.
-    // 3) Fill the solution into the captcha input and proceed.
-    // For now, we just throw to remind you to wire it.
-    throw new Error('2Captcha mode selected, but solver not yet implemented here.');
+    await img.waitFor({ state: 'visible', timeout: 10000 });
+    const buffer = await img.screenshot();
+    const solution = await solveWith2Captcha(buffer.toString('base64'), apiKey);
+
+    const input = page.locator('#con_txtcode, input[name*="code" i], input[placeholder*="驗證碼"]').first();
+    await input.fill(solution);
+    return;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add configurable CAPTCHA solver using 2Captcha service
- Extract solving logic into standalone `captcha_solver.js`
- Document CAPTCHA environment variables and usage

## Testing
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1181/chrome-linux/chrome)*
- `npx playwright install chromium` *(fails: Download failed: server returned code 403 body 'Forbidden'. URL: https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1181/chromium-linux.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e8ca79708325806acd8695a430fe